### PR TITLE
Content Type bug fix for CategoryData

### DIFF
--- a/src/Geta.Optimizely.Categories/CategoryData.cs
+++ b/src/Geta.Optimizely.Categories/CategoryData.cs
@@ -10,6 +10,7 @@ using EPiServer.Web.Routing;
 
 namespace Geta.Optimizely.Categories
 {
+    [ContentType(GUID = "9eba3e01-21b3-416e-b335-4911b07cf106", AvailableInEditMode = false)]
     [AvailableContentTypes(Availability = Availability.Specific, Include = new[] { typeof(CategoryData) })]
     public class CategoryData : StandardContentBase, IRoutable
     {

--- a/src/Geta.Optimizely.Categories/Geta.Optimizely.Categories.csproj
+++ b/src/Geta.Optimizely.Categories/Geta.Optimizely.Categories.csproj
@@ -16,6 +16,9 @@
     <PackageReleaseNotes>https://github.com/Geta/geta-optimizely-categories/blob/master/CHANGELOG.md</PackageReleaseNotes>
     <PackageTags>Geta Optimizely Categories</PackageTags>
     <RepositoryUrl>https://github.com/Geta/geta-optimizely-categories.git</RepositoryUrl>
+    <Version>1.0.1</Version>
+    <AssemblyVersion>1.0.1</AssemblyVersion>
+    <FileVersion>1.0.1</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Based on the same kind of submission for a bug fix in Geta.EpiCategories, I have added the ContentType attribute to the CategoryData object with a GUID, and setting EditMode to False. This allows Export and Import functionality to work. 