### PR TITLE
categories hierarchy handling & routing improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ public interface ICategoryContentLoader
     IEnumerable<T> GetSiteCategories<T>() where T : CategoryData;
     //... + overloads
     bool TryGet<T>(ContentReference categoryLink, out T category) where T : CategoryData;
+    //... + overloads
+    IEnumerable<T> GetCategoriesBySegment<T>(string urlSegment) where T : CategoryData;
+    //... + overloads
+    T GetCategoryByPath<T>(string path) where T : CategoryData;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Instead of going to admin mode to manage categories, you now do it in edit mode,
   - Possibility to hide root categories based on [AllowedTypes] setting
 - ShowDefaultCategoryProperty - default to **false**
   - Allows you to show the default Episerver category property
+- UseUrlPathForCategoryRetrieval - default to **false**
+  - Enables retrieval of categories that match the exact URL path instead of searching for a URL segment.
 
 You can configure categories in Startup.cs. Below is an example where we change the category seperator:
 
@@ -102,7 +104,8 @@ In addition, the configuration can be read from the `appsettings.json`:
       "CategorySeparator":  "__",
       "DisableCategoryAsLinkableType": false,
       "HideDisallowedRootCategories": false,
-      "ShowDefaultCategoryProperty": false
+      "ShowDefaultCategoryProperty": false,
+      "UseUrlPathForCategoryRetrieval": false
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Two routes are mapped during initialization. One for site categories and one for
 
 ![for this site routing](/docs/for-this-site.jpg)
 
-Using above example, the URL "/siteassets/topics/sports/" would be routed to the site category called "Sports". Similarly you could go to "/globalassets/topics/global-category-1" for the global category "Global category 1".
+As illustrated in the given example, if the UseUrlPathForCategoryRetrieval is enabled (set to true), navigating to the URL "/topics/sports/" directs you to the site's "Sports" category. In a similar manner, accessing "/global-topics/global-category-1" takes you to the "Global category 1". On the other hand, when UseUrlPathForCategoryRetrieval is disabled (set to false), the URL "/topics/sports/" will retrieve all categories associated with the segment "sports". Likewise, the URL "/global-topics/global-category-1" will fetch all categories, both global and site-specific, linked with the segment "global-category-1"
 
 ### ICategoryRoutableContent interface
 

--- a/src/Geta.Optimizely.Categories/Configuration/CategoriesOptions.cs
+++ b/src/Geta.Optimizely.Categories/Configuration/CategoriesOptions.cs
@@ -6,6 +6,7 @@ namespace Geta.Optimizely.Categories.Configuration
     public class CategoriesOptions
     {
         public string CategorySeparator { get; set; } = "__";
+        public bool UseUrlPathForCategoryRetrieval { get; set; }
         public bool DisableCategoryAsLinkableType { get; set; }
         public bool HideDisallowedRootCategories { get; set; }
         public bool ShowDefaultCategoryProperty { get; set; }

--- a/src/Geta.Optimizely.Categories/ICategoryContentLoader.cs
+++ b/src/Geta.Optimizely.Categories/ICategoryContentLoader.cs
@@ -25,6 +25,22 @@ namespace Geta.Optimizely.Categories
 
         T GetFirstBySegment<T>(ContentReference parentLink, string urlSegment, LoaderOptions loaderOptions) where T : CategoryData;
 
+        IEnumerable<T> GetCategoriesBySegment<T>(string urlSegment) where T : CategoryData;
+
+        IEnumerable<T> GetCategoriesBySegment<T>(string urlSegment, CultureInfo culture) where T : CategoryData;
+
+        IEnumerable<T> GetCategoriesBySegment<T>(string urlSegment, LoaderOptions loaderOptions) where T : CategoryData;
+
+        IEnumerable<T> GetCategoriesBySegment<T>(ContentReference parentLink, string urlSegment, LoaderOptions loaderOptions) where T : CategoryData;
+
+        T GetCategoryByPath<T>(string path) where T : CategoryData;
+        
+        T GetCategoryByPath<T>(string path, CultureInfo culture) where T : CategoryData;
+        
+        T GetCategoryByPath<T>(string path, LoaderOptions loaderOptions) where T : CategoryData;
+       
+        T GetCategoryByPath<T>(ContentReference parentLink, string urlSegment, LoaderOptions loaderOptions) where T : CategoryData;
+
         IEnumerable<T> GetGlobalCategories<T>() where T : CategoryData;
 
         IEnumerable<T> GetGlobalCategories<T>(CultureInfo culture) where T : CategoryData;

--- a/src/Geta.Optimizely.Categories/ICategoryContentLoader.cs
+++ b/src/Geta.Optimizely.Categories/ICategoryContentLoader.cs
@@ -39,7 +39,7 @@ namespace Geta.Optimizely.Categories
         
         T GetCategoryByPath<T>(string path, LoaderOptions loaderOptions) where T : CategoryData;
        
-        T GetCategoryByPath<T>(ContentReference parentLink, string urlSegment, LoaderOptions loaderOptions) where T : CategoryData;
+        T GetCategoryByPath<T>(ContentReference parentLink, string path, LoaderOptions loaderOptions) where T : CategoryData;
 
         IEnumerable<T> GetGlobalCategories<T>() where T : CategoryData;
 

--- a/src/Geta.Optimizely.Categories/Routing/CategoryModelBinder.cs
+++ b/src/Geta.Optimizely.Categories/Routing/CategoryModelBinder.cs
@@ -1,14 +1,18 @@
 // Copyright (c) Geta Digital. All rights reserved.
 // Licensed under Apache-2.0. See the LICENSE file in the project root for more information
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using EPiServer.Core;
 using EPiServer.Globalization;
+using EPiServer.Shell.Web;
 using EPiServer.Web.Routing;
+using Geta.Optimizely.Categories.Configuration;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Options;
 
 namespace Geta.Optimizely.Categories.Routing
 {
@@ -16,13 +20,18 @@ namespace Geta.Optimizely.Categories.Routing
     {
         private readonly ICategoryContentLoader _categoryContentLoader;
         private readonly IPageRouteHelper _pageRouteHelper;
+        private readonly CategoriesOptions _configuration;
+
+        private readonly string _trailingSlash = "/";
 
         public CategoryModelBinder(
             ICategoryContentLoader categoryContentLoader,
-            IPageRouteHelper pageRouteHelper)
+            IPageRouteHelper pageRouteHelper,
+            IOptions<CategoriesOptions> options)
         {
             _categoryContentLoader = categoryContentLoader;
             _pageRouteHelper = pageRouteHelper;
+            _configuration = options.Value;
         }
 
         public Task BindModelAsync(ModelBindingContext bindingContext)
@@ -39,11 +48,24 @@ namespace Geta.Optimizely.Categories.Routing
             {
                 return new List<CategoryData>();
             }
-            
-            var culture = (_pageRouteHelper.Content as ILocale).Language ?? ContentLanguage.PreferredCulture;
 
-            return categorySegments.Select(x => _categoryContentLoader.GetFirstBySegment<CategoryData>(x, culture))
-                                   .ToList();
+            var preferredCulture = (_pageRouteHelper.Content as ILocale).Language ?? ContentLanguage.PreferredCulture;
+
+            var categories = new List<CategoryData>();
+
+            foreach (var categorySegment in categorySegments)
+            {
+                if (_configuration.UseUrlPathForCategoryRetrieval)
+                {
+                    categories.Add(_categoryContentLoader.GetCategoryByPath<CategoryData>(categorySegment, preferredCulture));
+                }
+                else
+                {
+                    categories.AddRange(_categoryContentLoader.GetCategoriesBySegment<CategoryData>(categorySegment, preferredCulture));
+                }
+            }
+
+            return categories.Distinct().ToList();
         }
     }
 }

--- a/src/Geta.Optimizely.Categories/Routing/CategoryPartialRouter.cs
+++ b/src/Geta.Optimizely.Categories/Routing/CategoryPartialRouter.cs
@@ -3,13 +3,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using EPiServer;
 using EPiServer.Core;
 using EPiServer.Core.Routing;
 using EPiServer.Core.Routing.Pipeline;
-using EPiServer.DataAbstraction;
 using EPiServer.Globalization;
 using EPiServer.Shell.Web;
 using EPiServer.Web;


### PR DESCRIPTION
The current routing implementation is chaotic and does not function as intended.

To illustrate, let's consider a scenario where both global and site categories are enabled. In this case, accessing the **/jobs** URL path retrieves only one category from the site categories. This limitation arises due to the **GetFirstBySegment** function within the **ICategoryContentLoader** interface, which fails to aggregate adequately despite searching through descendants of the root. To resolve this, I introduced a new function named **GetCategoriesBySegment**. With an overload, this enhanced function searches for all categories associated with the **'jobs'** segment globally or across sites and returns them via the **IList<CategoryData> currentCategories** parameter in the controller.

The second issue pertains to path routing. According to the current documentation, paths like **/siteassets/topics/sports/** and **/globalassets/topics/global-category-1** should be functional, yet they are not. A trailing slash results in a 404 error. Furthermore, even if this were rectified, the **CategoryPartialRouter's** **nextSegment.Next** method would neglect the entire path, focusing solely on the segment for category retrieval. To address this, while maintaining the existing framework, I have introduced an option within CategoryOption called **UseUrlPathForCategoryRetrieval**. When enabled, this option ensures that category retrieval is based on the entire path rather than just the segment. the lookup path started with category root instead of **siteassets** or **globalassets** e.g  **/topics/sports/**  **/topics/global-category-1** if both root category for global and site-specific has **topics** as segment.